### PR TITLE
Fix: Perbaiki konfigurasi Render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -12,11 +12,10 @@ services:
         value: 3.11.5
 
   # Frontend Service (React Static Site)
-  - type: static
+  - type: static_site
     name: naskyai-frontend
-    env: static
     buildCommand: "npm install && npm run build"
-    staticPublishPath: "./dist"
+    staticPublishPath: "dist"
     routes:
       - type: rewrite
         source: /*


### PR DESCRIPTION
- Mengubah tipe layanan frontend dari `static` menjadi `static_site`.
- Menghapus baris `env: static` yang tidak valid.
- Membersihkan path `staticPublishPath`.