### PR TITLE
Fix: Sederhanakan konfigurasi Vite untuk Vercel

### DIFF
--- a/com/mhire/ui/vite.config.ts
+++ b/com/mhire/ui/vite.config.ts
@@ -4,23 +4,28 @@ import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  root: 'com/mhire/ui',
+  // We no longer use `root` to avoid pathing issues in Vercel's build environment.
+  // Instead, we specify the input directly in rollupOptions.
   server: {
     host: "::",
     port: 8080
   },
   plugins: [
-  react()],
-
+    react()
+  ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "src")
+      // Alias must point to the full path from the project root
+      "@": path.resolve(__dirname, "com/mhire/ui/src")
     }
   },
   build: {
-    outDir: '../../dist',
+    // Output to a 'dist' directory at the project root
+    outDir: 'dist',
     sourcemap: mode === 'development',
     rollupOptions: {
+      // Specify the entry point of the application
+      input: 'com/mhire/ui/index.html',
       output: {
         manualChunks: {
           vendor: ['react', 'react-dom', 'react-router-dom'],


### PR DESCRIPTION
- Menghapus properti `root` dan `outDir` yang ambigu.
- Menentukan input build secara eksplisit melalui `rollupOptions.input`.
- Mengatur `outDir` ke `dist` di root proyek untuk kompatibilitas Vercel.